### PR TITLE
Remove duplicate info server

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -184,7 +184,6 @@
   "house": "whois.nic.house",
   "immobilien": "whois.nic.immobilien",
   "industries": "whois.nic.industries",
-  "info": "whois.nic.info",
   "ink": "whois.nic.ink",
   "institute": "whois.nic.institute",
   "insure": "whois.nic.insure",


### PR DESCRIPTION
.info had two entries in servers.json, remove the one that doesn't work.
This bug can be verified by running:

```node index.js google.info```